### PR TITLE
Remove a MUST that we cannot enforce

### DIFF
--- a/draft-ietf-deleg.md
+++ b/draft-ietf-deleg.md
@@ -381,7 +381,7 @@ This restriction only applies to a single DELEG or DELEGI record; a DELEG or DEL
 
 When using server-name, the addresses for all the names in the set must be fetched using normal DNS resolution.
 This means the names in the value of the server-name key or the include-delegi key cannot sensibly be inside the delegated domain.
-Resolvers thus will ignore nameserver names in the server-name key or the include-delegi key if they are in the delegated domain.
+Resolvers MUST ignore names in the server-name key or the include-delegi key if they are in the delegated domain.
 
 With this initial DELEG specification, servers are still expected to be reached on the standard DNS port for both UDP and TCP, 53.  While a future specification is expected to address other transports using other ports, its eventual semantics are not covered here.
 


### PR DESCRIPTION
The replaced text has a MUST that we cannot enforce. Further, because server-name and include-delegi can be a set of names, if one name in the set might be bad and the others fine, so we should not tell the resolver to ignore the whole set.